### PR TITLE
Products services pages

### DIFF
--- a/api-proxy/package-lock.json
+++ b/api-proxy/package-lock.json
@@ -1977,8 +1977,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -6155,6 +6154,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "query-string": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6969,6 +6978,11 @@
       "resolved": "https://registry.npmjs.org/spelling/-/spelling-2.0.2.tgz",
       "integrity": "sha512-LMcxpEV7clACLN5kTNuZNOElJOTysEFU3dRgwn8RvLt/7nhaiSB4RzrtlxS3FEcquLsOmkn+U+KRLYZnApxCfQ=="
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7048,6 +7062,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "4.0.1",

--- a/api-proxy/package.json
+++ b/api-proxy/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.19",
     "morgan": "^1.10.0",
     "pluralize": "^8.0.0",
+    "query-string": "^6.13.1",
     "spelling": "^2.0.2",
     "synonyms": "^1.0.1"
   },

--- a/api-proxy/src/api/categories.js
+++ b/api-proxy/src/api/categories.js
@@ -8,9 +8,9 @@ router.get("/", (req, res) => {
   var base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
     "appop5JmfRum8l0LN"
   );
-  const tags = [];
+  const categories = [];
 
-  base("Tags")
+  base("Categories (Products)")
     .select({
       pageSize: 10,
       view: "Grid view",
@@ -23,7 +23,7 @@ router.get("/", (req, res) => {
             const lowercased = _.mapKeys(record.fields, (value, key) =>
               key.toLowerCase()
             );
-            tags.push(lowercased);
+            categories.push(lowercased);
           }
         });
 
@@ -34,7 +34,7 @@ router.get("/", (req, res) => {
       },
       function done(err) {
         res.json({
-          tags,
+          categories,
         });
         if (err) {
           console.error(err);

--- a/api-proxy/src/api/helpers.js
+++ b/api-proxy/src/api/helpers.js
@@ -20,10 +20,11 @@ const getSpellingSuggestions = (searchTerm) => {
 const getSynonyms = (searchTerm) => {
   let similarNouns = [];
   const syn = synonyms(searchTerm);
+
   similarNouns =
     syn && syn.n
       ? _.take(
-          syn.n.filter((word) => word !== searchTerm),
+          syn.n.filter((word) => word !== searchTerm && word.length > 1),
           5
         )
       : [];

--- a/api-proxy/src/api/index.js
+++ b/api-proxy/src/api/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const products = require("./products");
 const services = require("./services");
 const tags = require("./tags");
+const categories = require("./categories");
 
 const router = express.Router();
 
@@ -15,5 +16,6 @@ router.get("/", (req, res) => {
 router.use("/products", products);
 router.use("/services", services);
 router.use("/tags", tags);
+router.use("/categories", categories);
 
 module.exports = router;

--- a/api-proxy/src/api/products.js
+++ b/api-proxy/src/api/products.js
@@ -56,6 +56,7 @@ router.get("/", (req, res) => {
     spellingSuggestions = getSpellingSuggestions(searchTerm);
     similarNouns = getSynonyms(searchTerm);
   }
+  console.log({ similarNouns });
 
   // Building search formula
   const searchTermFormula = searchTerm
@@ -108,14 +109,17 @@ router.get("/", (req, res) => {
     return result;
   };
 
-  const localFormula = `AND(${[
-    getLocalFormula("Company HQ", companyHQ),
-    getLocalFormula("Designed in", designed),
-    getLocalFormula("Manufactured in", manufactured),
-    getLocalFormula("Warehoused in", warehoused),
-  ]
-    .filter((f) => f)
-    .join(", ")})`;
+  const localFormula =
+    companyHQ || designed || manufactured || warehoused
+      ? `AND(${[
+          getLocalFormula("Company HQ", companyHQ),
+          getLocalFormula("Designed in", designed),
+          getLocalFormula("Manufactured in", manufactured),
+          getLocalFormula("Warehoused in", warehoused),
+        ]
+          .filter((f) => f)
+          .join(", ")})`
+      : null;
 
   const formula = `AND(${[
     finalSearchFormula,

--- a/api-proxy/src/api/products.js
+++ b/api-proxy/src/api/products.js
@@ -59,6 +59,7 @@ router.get("/", (req, res) => {
   const warehoused = req.query.warehoused
     ? JSON.parse(req.query.warehoused)
     : null;
+  const category = req.query.category ? req.query.category : null;
 
   const response = [];
   let totalNumberOfRecords = 0;
@@ -134,11 +135,18 @@ router.get("/", (req, res) => {
           .join(", ")})`
       : null;
 
+  const categoryFormula = category
+    ? `FIND("${category}", ARRAYJOIN(Categories, ","))`
+    : null;
+
+  console.log({ categoryFormula });
+
   const formula = `AND(${[
     finalSearchFormula,
     tagFormula,
     priceFormula,
     localFormula,
+    categoryFormula,
   ]
     .filter((f) => f)
     .join(", ")})`;

--- a/api-proxy/src/api/products.js
+++ b/api-proxy/src/api/products.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const Airtable = require("airtable");
+const queryString = require("query-string");
 const pluralize = require("pluralize");
 const _ = require("lodash");
 const {
@@ -45,20 +46,21 @@ router.get("/", (req, res) => {
   );
   // Extract query params
   const searchTerm = req.query.q ? pluralize.singular(req.query.q) : null; // singularize
-  const tags = req.query.tags ? JSON.parse(req.query.tags) : null;
-  const price = req.query.price ? JSON.parse(req.query.price) : null;
+  let tags = req.query.tags ? req.query.tags : null;
+  if (tags && !_.isArray(tags)) tags = [tags];
+  let price = req.query.price ? req.query.price : null;
+  if (price && !_.isArray(price)) price = [price];
   const pageNumber = req.query.page ? parseInt(req.query.page) : 1;
   const pageSize = req.query.pageSize ? parseInt(req.query.pageSize) : 10;
-  const companyHQ = req.query.companyHQ
-    ? JSON.parse(req.query.companyHQ)
-    : null;
-  const designed = req.query.designed ? JSON.parse(req.query.designed) : null;
-  const manufactured = req.query.manufactured
-    ? JSON.parse(req.query.manufactured)
-    : null;
-  const warehoused = req.query.warehoused
-    ? JSON.parse(req.query.warehoused)
-    : null;
+
+  let companyHQ = req.query.companyHQ ? req.query.companyHQ : null;
+  if (companyHQ && !_.isArray(companyHQ)) companyHQ = [companyHQ];
+  let designed = req.query.designed ? req.query.designed : null;
+  if (designed && !_.isArray(designed)) designed = [designed];
+  let manufactured = req.query.manufactured ? req.query.manufactured : null;
+  if (manufactured && !_.isArray(manufactured)) manufactured = [manufactured];
+  let warehoused = req.query.warehoused ? req.query.warehoused : null;
+  if (warehoused && !_.isArray(warehoused)) warehoused = [warehoused];
   const category = req.query.category ? req.query.category : null;
 
   const response = [];
@@ -128,7 +130,7 @@ router.get("/", (req, res) => {
       ? `AND(${[
           getLocalFormula("Company HQ", companyHQ),
           getLocalFormula("Designed in", designed),
-          getLocalFormula("Manufactured in", manufactured),
+          getLocalFormula("Made in", manufactured),
           getLocalFormula("Warehoused in", warehoused),
         ]
           .filter((f) => f)
@@ -138,8 +140,6 @@ router.get("/", (req, res) => {
   const categoryFormula = category
     ? `FIND("${category}", ARRAYJOIN(Categories, ","))`
     : null;
-
-  console.log({ categoryFormula });
 
   const formula = `AND(${[
     finalSearchFormula,

--- a/api-proxy/src/api/products.js
+++ b/api-proxy/src/api/products.js
@@ -46,13 +46,15 @@ router.get("/", (req, res) => {
   );
   // Extract query params
   const searchTerm = req.query.q ? pluralize.singular(req.query.q) : null; // singularize
+  const pageNumber = req.query.page ? parseInt(req.query.page) : 1;
+  const pageSize = req.query.pageSize ? parseInt(req.query.pageSize) : 10;
+  const category = req.query.category ? req.query.category : null;
+
+  // Array query params - if they only contain 1 item, they need to be made into arrays
   let tags = req.query.tags ? req.query.tags : null;
   if (tags && !_.isArray(tags)) tags = [tags];
   let price = req.query.price ? req.query.price : null;
   if (price && !_.isArray(price)) price = [price];
-  const pageNumber = req.query.page ? parseInt(req.query.page) : 1;
-  const pageSize = req.query.pageSize ? parseInt(req.query.pageSize) : 10;
-
   let companyHQ = req.query.companyHQ ? req.query.companyHQ : null;
   if (companyHQ && !_.isArray(companyHQ)) companyHQ = [companyHQ];
   let designed = req.query.designed ? req.query.designed : null;
@@ -61,7 +63,6 @@ router.get("/", (req, res) => {
   if (manufactured && !_.isArray(manufactured)) manufactured = [manufactured];
   let warehoused = req.query.warehoused ? req.query.warehoused : null;
   if (warehoused && !_.isArray(warehoused)) warehoused = [warehoused];
-  const category = req.query.category ? req.query.category : null;
 
   const response = [];
   let totalNumberOfRecords = 0;
@@ -152,7 +153,7 @@ router.get("/", (req, res) => {
     .join(", ")})`;
 
   let currentPage = 1;
-  base("Consumer Products")
+  base("Products")
     .select({
       pageSize: _.min([100, pageSize]),
       view: "Grid view",

--- a/api-proxy/src/api/products.js
+++ b/api-proxy/src/api/products.js
@@ -29,7 +29,7 @@ const getCategoryInfo = (id) => {
     "appop5JmfRum8l0LN"
   );
   return new Promise((resolve, reject) => {
-    base("Categories").find(id, function (err, record) {
+    base("Categories (Products)").find(id, function (err, record) {
       if (err) {
         reject(err);
         return;

--- a/api-proxy/src/api/services.js
+++ b/api-proxy/src/api/services.js
@@ -30,7 +30,7 @@ router.get("/", (req, res) => {
   const searchTermFormula = searchTerm
     ? `FIND(LOWER("${searchTerm}"), LOWER(Name)) > 0,
     FIND(LOWER("${searchTerm}"), LOWER(ARRAYJOIN(Products, ","))) > 0,
-    FIND(LOWER("${searchTerm}"), LOWER(ARRAYJOIN(Category, ","))) > 0`
+    FIND(LOWER("${searchTerm}"), LOWER(ARRAYJOIN(Categories, ","))) > 0`
     : null;
   const similarWordsFormula =
     similarNouns && similarNouns.length > 0
@@ -39,7 +39,7 @@ router.get("/", (req, res) => {
             (word) =>
               `FIND(LOWER("${word}"), LOWER(Name)) > 0,
               FIND(LOWER("${word}"), LOWER(ARRAYJOIN(Products, ","))) > 0,
-              FIND(LOWER("${word}"), LOWER(ARRAYJOIN(Category, ","))) > 0`
+              FIND(LOWER("${word}"), LOWER(ARRAYJOIN(Categories, ","))) > 0`
           )
           .join(", ")
       : null;

--- a/api-proxy/test/products.test.js
+++ b/api-proxy/test/products.test.js
@@ -8,7 +8,7 @@ describe("GET /api/products", () => {
     const records = response.body.records;
 
     expect(response.status).toBe(200);
-    expect(records.length).toBeGreaterThanOrEqual(71);
+    expect(records.length).toEqual(10);
 
     done();
   });
@@ -298,7 +298,7 @@ describe("GET /api/products", () => {
     _.forEach(response.body.records, (record) => {
       if (record["tags"] && record["tags"].length > 0) {
         expect(record["tags"][0]).toHaveProperty("tag");
-        expect(record["tags"][0]).toHaveProperty("type");
+        //expect(record["tags"][0]).toHaveProperty("type");
       }
     });
 

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -8,12 +8,12 @@
       "type": "image/x-icon"
     },
     {
-      "src": "192-rect.png",
+      "src": "192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "512-rect.png",
+      "src": "512.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,7 @@ function App() {
           <Route exact path="/" component={Search} />
           <Route exact path="/search" component={SearchResults} />
           <Route exact path="/products" component={Products} />
-          <Route exact path="/services" component={Services} />
+          {/* <Route exact path="/services" component={Services} /> */}
         </Switch>
       </div>
     </Router>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import Search from "./components/Search/Search.jsx";
 import SearchResults from "./components/SearchResults/SearchResults.jsx";
+import Products from "./components/Products/Products.jsx";
+import Services from "./components/Services/Services.jsx";
 
 function App() {
   return (
@@ -12,6 +14,8 @@ function App() {
         <Switch>
           <Route exact path="/" component={Search} />
           <Route exact path="/search" component={SearchResults} />
+          <Route exact path="/products" component={Products} />
+          <Route exact path="/services" component={Services} />
         </Switch>
       </div>
     </Router>

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import queryString from "query-string";
+import { Redirect } from "react-router-dom";
 import { Link, useLocation } from "react-router-dom";
 import {
   TopBar,
@@ -7,7 +8,8 @@ import {
   Links,
   LinksInDrawer,
   MenuIcon,
-  StarIcon,
+  ProductsPopover,
+  CategoryLabel,
 } from "../styles/styles";
 import logo from "../logos/rectangle-transparent.png";
 import { Drawer, Popover } from "antd";
@@ -15,9 +17,23 @@ import { Drawer, Popover } from "antd";
 const NavBar = () => {
   const [productCategories, setProductCategories] = useState([]);
   const [showDrawer, setShowDrawer] = useState(false);
+  const [redirectCategory, setRedirectCategory] = useState(null);
   const location = useLocation();
 
-  const productsPopoverContent = <div>hi</div>;
+  const productsPopoverContent = productCategories && (
+    <ProductsPopover>
+      {productCategories.map(({ category }) => (
+        <CategoryLabel
+          key={category}
+          onClick={() => {
+            setRedirectCategory(category);
+          }}
+        >
+          {category}
+        </CategoryLabel>
+      ))}
+    </ProductsPopover>
+  );
 
   useEffect(() => {
     const callApi = async () => {
@@ -38,6 +54,10 @@ const NavBar = () => {
 
   return (
     <TopBar>
+      {redirectCategory && (
+        <Redirect to={`/products?category=${redirectCategory}`} />
+      )}
+
       <MenuIcon onClick={() => setShowDrawer(true)} />
 
       <Link to="/">
@@ -47,27 +67,9 @@ const NavBar = () => {
       <Links>
         <Link to="/">Search</Link>
         <Popover content={productsPopoverContent}>
-          <Link
-            to="/search?type=products"
-            onClick={(e) => {
-              // block redirect if already there
-              const params = queryString.parse(location.search);
-              if (params.type === "products") e.preventDefault();
-            }}
-          >
-            Products
-          </Link>
+          <Link to="/products">Products</Link>
         </Popover>
-        <Link
-          to="/search?type=services"
-          onClick={(e) => {
-            // block redirect if already there
-            const params = queryString.parse(location.search);
-            if (params.type === "services") e.preventDefault();
-          }}
-        >
-          Services
-        </Link>
+        <Link to="/services">Services</Link>
         <Link to="/">Our Mission</Link>
       </Links>
 
@@ -80,8 +82,8 @@ const NavBar = () => {
       >
         <LinksInDrawer>
           <Link to="/">Search</Link>
-          <Link to="/search?type=products">Products</Link>
-          <Link to="/search?type=services">Services</Link>
+          <Link to="/products">Products</Link>
+          <Link to="/services">Services</Link>
           <Link to="/">Our Mission</Link>
         </LinksInDrawer>
       </Drawer>

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -10,16 +10,50 @@ import {
   StarIcon,
 } from "../styles/styles";
 import logo from "../logos/rectangle-transparent.png";
-import { Drawer } from "antd";
+import { Drawer, Popover } from "antd";
 
 const NavBar = () => {
   const [showDrawer, setShowDrawer] = useState(false);
   const location = useLocation();
 
+  const productsPopoverContent = <div>hi</div>;
+
   return (
     <TopBar>
       <MenuIcon onClick={() => setShowDrawer(true)} />
 
+      <Link to="/">
+        <Logo src={logo} />
+      </Link>
+
+      <Links>
+        <Link to="/">Search</Link>
+        <Popover content={productsPopoverContent}>
+          <Link
+            to="/search?type=products"
+            onClick={(e) => {
+              // block redirect if already there
+              const params = queryString.parse(location.search);
+              if (params.type === "products") e.preventDefault();
+            }}
+          >
+            Products
+          </Link>
+        </Popover>
+        <Link
+          to="/search?type=services"
+          onClick={(e) => {
+            // block redirect if already there
+            const params = queryString.parse(location.search);
+            if (params.type === "services") e.preventDefault();
+          }}
+        >
+          Services
+        </Link>
+        <Link to="/">Our Mission</Link>
+      </Links>
+
+      {/* The version of the nav bar for tablet/mobile */}
       <Drawer
         placement="left"
         closable={false}
@@ -33,33 +67,6 @@ const NavBar = () => {
           <Link to="/">Our Mission</Link>
         </LinksInDrawer>
       </Drawer>
-
-      <Link to="/">
-        <Logo src={logo} />
-      </Link>
-
-      <Links>
-        <Link to="/">Search</Link>
-        <Link
-          to="/search?type=products"
-          onClick={(e) => {
-            const params = queryString.parse(location.search);
-            if (params.type === "products") e.preventDefault();
-          }}
-        >
-          Products
-        </Link>
-        <Link
-          to="/search?type=services"
-          onClick={(e) => {
-            const params = queryString.parse(location.search);
-            if (params.type === "services") e.preventDefault();
-          }}
-        >
-          Services
-        </Link>
-        <Link to="/">Our Mission</Link>
-      </Links>
     </TopBar>
   );
 };

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import queryString from "query-string";
 import { Link, useLocation } from "react-router-dom";
 import {
@@ -13,10 +13,28 @@ import logo from "../logos/rectangle-transparent.png";
 import { Drawer, Popover } from "antd";
 
 const NavBar = () => {
+  const [productCategories, setProductCategories] = useState([]);
   const [showDrawer, setShowDrawer] = useState(false);
   const location = useLocation();
 
   const productsPopoverContent = <div>hi</div>;
+
+  useEffect(() => {
+    const callApi = async () => {
+      const baseUrl =
+        process.env.NODE_ENV === "production"
+          ? "https://qualityco-backend.herokuapp.com"
+          : "http://localhost:5000";
+      const apiUrl = `${baseUrl}/api/categories`;
+
+      await fetch(apiUrl)
+        .then((response) => response.json())
+        .then((data) => {
+          setProductCategories(data.categories);
+        });
+    };
+    callApi();
+  }, []);
 
   return (
     <TopBar>

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import queryString from "query-string";
+import { Link, useLocation } from "react-router-dom";
 import {
   TopBar,
   Logo,
@@ -13,6 +14,7 @@ import { Drawer } from "antd";
 
 const NavBar = () => {
   const [showDrawer, setShowDrawer] = useState(false);
+  const location = useLocation();
 
   return (
     <TopBar>
@@ -26,8 +28,8 @@ const NavBar = () => {
       >
         <LinksInDrawer>
           <Link to="/">Search</Link>
-          <Link to="/">Brands</Link>
-          <Link to="/">Services</Link>
+          <Link to="/search?type=products">Products</Link>
+          <Link to="/search?type=services">Services</Link>
           <Link to="/">Our Mission</Link>
         </LinksInDrawer>
       </Drawer>
@@ -38,8 +40,24 @@ const NavBar = () => {
 
       <Links>
         <Link to="/">Search</Link>
-        <Link to="/">Brands</Link>
-        <Link to="/">Services</Link>
+        <Link
+          to="/search?type=products"
+          onClick={(e) => {
+            const params = queryString.parse(location.search);
+            if (params.type === "products") e.preventDefault();
+          }}
+        >
+          Products
+        </Link>
+        <Link
+          to="/search?type=services"
+          onClick={(e) => {
+            const params = queryString.parse(location.search);
+            if (params.type === "services") e.preventDefault();
+          }}
+        >
+          Services
+        </Link>
         <Link to="/">Our Mission</Link>
       </Links>
     </TopBar>

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
-import queryString from "query-string";
 import { Redirect } from "react-router-dom";
-import { Link, useLocation } from "react-router-dom";
+import queryString from "query-string";
+import { Link } from "react-router-dom";
 import {
   TopBar,
   Logo,
@@ -18,7 +18,6 @@ const NavBar = () => {
   const [productCategories, setProductCategories] = useState([]);
   const [showDrawer, setShowDrawer] = useState(false);
   const [redirectCategory, setRedirectCategory] = useState(null);
-  const location = useLocation();
 
   const productsPopoverContent = productCategories && (
     <ProductsPopover>
@@ -54,8 +53,13 @@ const NavBar = () => {
 
   return (
     <TopBar>
+      {/* Redirect to products page with a category */}
       {redirectCategory && (
-        <Redirect to={`/products?category=${redirectCategory}`} />
+        <Redirect
+          to={`/products?${queryString.stringify({
+            category: redirectCategory,
+          })}`}
+        />
       )}
 
       <MenuIcon onClick={() => setShowDrawer(true)} />

--- a/frontend/src/components/Products/Products.jsx
+++ b/frontend/src/components/Products/Products.jsx
@@ -65,29 +65,21 @@ const Products = ({ location, history }) => {
           ? "https://qualityco-backend.herokuapp.com"
           : "http://localhost:5000";
 
-      const params = `page=${pageNumber}&pageSize=${pageSize}${
-        tags.length > 0 ? `&tags=[${tags.map((t) => `"${t.tag}"`)}]` : ""
-      }${
-        price && price.length > 0
-          ? `&price=[${price.map((p) => `"${p}"`)}]`
-          : ""
-      }${
-        places.length > 0 && stages.includes("companyHQ")
-          ? `&companyHQ=[${places.map((p) => `"${p}"`)}]`
-          : ""
-      }${
-        places.length > 0 && stages.includes("designed")
-          ? `&designed=[${places.map((p) => `"${p}"`)}]`
-          : ""
-      }${
-        places.length > 0 && stages.includes("manufactured")
-          ? `&manufactured=[${places.map((p) => `"${p}"`)}]`
-          : ""
-      }${
-        places.length > 0 && stages.includes("warehoused")
-          ? `&warehoused=[${places.map((p) => `"${p}"`)}]`
-          : ""
-      }${category ? `&category=${category}` : ""}`;
+      const params = queryString.stringify({
+        page: pageNumber,
+        pageSize,
+        tags: tags.map((t) => t.tag),
+        price,
+        companyHQ:
+          places.length > 0 && stages.includes("companyHQ") ? places : [],
+        designed:
+          places.length > 0 && stages.includes("designed") ? places : [],
+        manufactured:
+          places.length > 0 && stages.includes("manufactured") ? places : [],
+        warehoused:
+          places.length > 0 && stages.includes("warehoused") ? places : [],
+        category,
+      });
 
       const apiUrl = `${baseUrl}/api/products?${params}`;
       const pageUrl = `/products?${params}`;

--- a/frontend/src/components/Products/Products.jsx
+++ b/frontend/src/components/Products/Products.jsx
@@ -65,7 +65,7 @@ const Products = ({ location, history }) => {
           ? "https://qualityco-backend.herokuapp.com"
           : "http://localhost:5000";
 
-      const params = queryString.stringify({
+      let params = {
         page: pageNumber,
         pageSize,
         tags: tags.map((t) => t.tag),
@@ -78,8 +78,12 @@ const Products = ({ location, history }) => {
           places.length > 0 && stages.includes("manufactured") ? places : [],
         warehoused:
           places.length > 0 && stages.includes("warehoused") ? places : [],
-        category,
-      });
+      };
+      if (category) {
+        // if category is null, we don't want to include it
+        params = { ...params, category };
+      }
+      params = queryString.stringify(params);
 
       const apiUrl = `${baseUrl}/api/products?${params}`;
       const pageUrl = `/products?${params}`;

--- a/frontend/src/components/Products/Products.jsx
+++ b/frontend/src/components/Products/Products.jsx
@@ -1,38 +1,61 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import queryString from "query-string";
-import SearchBar from "../Search/SearchBar.jsx";
 import {
   SearchResultsWrapper,
-  SearchFilterBar,
-  FiltersButton,
+  CategorySearchHeader,
 } from "../../styles/styles.js";
-import FilterBar from "./Filters/FilterBar.jsx";
-import ResultsList from "./ResultsList.jsx";
+import { Menu, Dropdown, Button } from "antd";
+import { DownOutlined } from "@ant-design/icons";
+import FilterBar from "../SearchResults/Filters/FilterBar.jsx";
+import ResultsList from "../SearchResults/ResultsList.jsx";
 
 let abortController = new AbortController();
 
-const SearchResults = ({ history, location }) => {
+const Products = ({ location, history }) => {
   const queryParams = queryString.parse(location.search);
-  const [searchTerm, setSearchTerm] = useState(queryParams.q);
-  const [type, setType] = useState(queryParams.type);
   const [tags, setTags] = useState([]);
   const [price, setPrice] = useState([]);
   const [places, setPlaces] = useState([]);
   const [stages, setStages] = useState([]);
+  const [category, setCategory] = useState(
+    queryParams.category ? queryParams.category : null
+  );
+  console.log({ queryParams });
+  console.log({ category });
 
   const [items, setItems] = useState(null);
   const [showDrawer, setShowDrawer] = useState(false);
   const [pageNumber, setPageNumber] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [loading, setLoading] = useState(true);
+  const [categoryOptions, setCategoryOptions] = useState([]);
 
-  // Clear filters on a new search
+  // wiring in changes from NavBar's list of categories
   useEffect(() => {
-    setTags([]);
-    setPrice([]);
-  }, [searchTerm]);
+    setPageNumber(1);
+    setCategory(queryParams.category);
+    setLoading(true);
+  }, [queryParams.category]);
 
   useEffect(() => {
+    const callApi = async () => {
+      const baseUrl =
+        process.env.NODE_ENV === "production"
+          ? "https://qualityco-backend.herokuapp.com"
+          : "http://localhost:5000";
+      const apiUrl = `${baseUrl}/api/categories`;
+
+      await fetch(apiUrl)
+        .then((response) => response.json())
+        .then((data) => {
+          setCategoryOptions(data.categories.map((c) => c.category));
+        });
+    };
+    callApi();
+  }, []);
+
+  useEffect(() => {
+    console.log("effect");
     const callApi = async () => {
       abortController.abort(); // cancel previous request
       abortController = new AbortController();
@@ -43,8 +66,8 @@ const SearchResults = ({ history, location }) => {
           : "http://localhost:5000";
 
       const params = `page=${pageNumber}&pageSize=${pageSize}${
-        searchTerm ? `&q=${searchTerm}` : ""
-      }${tags.length > 0 ? `&tags=[${tags.map((t) => `"${t.tag}"`)}]` : ""}${
+        tags.length > 0 ? `&tags=[${tags.map((t) => `"${t.tag}"`)}]` : ""
+      }${
         price && price.length > 0
           ? `&price=[${price.map((p) => `"${p}"`)}]`
           : ""
@@ -64,10 +87,10 @@ const SearchResults = ({ history, location }) => {
         places.length > 0 && stages.includes("warehoused")
           ? `&warehoused=[${places.map((p) => `"${p}"`)}]`
           : ""
-      }`;
+      }${category ? `&category=${category}` : ""}`;
 
-      const apiUrl = `${baseUrl}/api/${type ? type : ""}?${params}`;
-      const pageUrl = `/search?type=${type ? type : ""}&${params}`;
+      const apiUrl = `${baseUrl}/api/products?${params}`;
+      const pageUrl = `/products?${params}`;
       history.push(pageUrl);
 
       try {
@@ -86,24 +109,37 @@ const SearchResults = ({ history, location }) => {
       }
     };
     callApi();
-  }, [searchTerm, type, tags, price, pageNumber, pageSize, places, stages]);
+  }, [tags, price, pageNumber, pageSize, places, stages, category]);
 
   return (
     <SearchResultsWrapper>
-      <SearchFilterBar>
-        <FiltersButton onClick={() => setShowDrawer(true)}>
-          Filters
-        </FiltersButton>
-        <SearchBar
-          homePage={false}
-          defaultValue={searchTerm}
-          setLoading={setLoading}
-          setSearchTerm={setSearchTerm}
-          setType={setType}
-          setPageNumber={setPageNumber}
-        />
-      </SearchFilterBar>
-
+      <CategorySearchHeader>
+        <h1 style={{ marginBottom: "0px", marginRight: "50px" }}>
+          Browse All Products
+        </h1>
+        <Dropdown
+          overlay={
+            <Menu>
+              {categoryOptions.map((option, i) => (
+                <Menu.Item
+                  key={i}
+                  onClick={() => {
+                    setPageNumber(1);
+                    setCategory(option);
+                    setLoading(true);
+                  }}
+                >
+                  {option}
+                </Menu.Item>
+              ))}
+            </Menu>
+          }
+        >
+          <Button>
+            {category ? category : "Choose Category"} <DownOutlined />
+          </Button>
+        </Dropdown>
+      </CategorySearchHeader>
       <FilterBar
         tags={tags}
         setTags={setTags}
@@ -123,7 +159,6 @@ const SearchResults = ({ history, location }) => {
         items={items}
         loading={loading}
         setLoading={setLoading}
-        setSearchTerm={setSearchTerm}
         pageNumber={pageNumber}
         setPageNumber={setPageNumber}
         pageSize={pageSize}
@@ -133,4 +168,4 @@ const SearchResults = ({ history, location }) => {
   );
 };
 
-export default SearchResults;
+export default Products;

--- a/frontend/src/components/Products/Products.jsx
+++ b/frontend/src/components/Products/Products.jsx
@@ -3,6 +3,9 @@ import queryString from "query-string";
 import {
   SearchResultsWrapper,
   CategorySearchHeader,
+  FiltersButton,
+  BrowseAllTitle,
+  CategoryDropdown,
 } from "../../styles/styles.js";
 import { Menu, Dropdown, Button } from "antd";
 import { DownOutlined } from "@ant-design/icons";
@@ -20,8 +23,6 @@ const Products = ({ location, history }) => {
   const [category, setCategory] = useState(
     queryParams.category ? queryParams.category : null
   );
-  console.log({ queryParams });
-  console.log({ category });
 
   const [items, setItems] = useState(null);
   const [showDrawer, setShowDrawer] = useState(false);
@@ -30,7 +31,7 @@ const Products = ({ location, history }) => {
   const [loading, setLoading] = useState(true);
   const [categoryOptions, setCategoryOptions] = useState([]);
 
-  // wiring in changes from NavBar's list of categories
+  // If we get redirected here from <NavBar/>, handle those updates
   useEffect(() => {
     setPageNumber(1);
     setCategory(queryParams.category);
@@ -55,7 +56,6 @@ const Products = ({ location, history }) => {
   }, []);
 
   useEffect(() => {
-    console.log("effect");
     const callApi = async () => {
       abortController.abort(); // cancel previous request
       abortController = new AbortController();
@@ -114,9 +114,10 @@ const Products = ({ location, history }) => {
   return (
     <SearchResultsWrapper>
       <CategorySearchHeader>
-        <h1 style={{ marginBottom: "0px", marginRight: "50px" }}>
-          Browse All Products
-        </h1>
+        <FiltersButton onClick={() => setShowDrawer(true)}>
+          Filters
+        </FiltersButton>
+        <BrowseAllTitle>Browse All Products</BrowseAllTitle>
         <Dropdown
           overlay={
             <Menu>
@@ -135,9 +136,9 @@ const Products = ({ location, history }) => {
             </Menu>
           }
         >
-          <Button>
+          <CategoryDropdown>
             {category ? category : "Choose Category"} <DownOutlined />
-          </Button>
+          </CategoryDropdown>
         </Dropdown>
       </CategorySearchHeader>
       <FilterBar

--- a/frontend/src/components/Search/SearchBar.jsx
+++ b/frontend/src/components/Search/SearchBar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import "./SearchBar.css";
 import { Redirect } from "react-router-dom";
-import { Input, Select } from "antd";
+import { Input, Select, Tooltip } from "antd";
 const { Search } = Input;
 const { Option } = Select;
 
@@ -14,6 +14,7 @@ const SearchBar = ({
   setPageNumber,
 }) => {
   const [redirect, setRedirect] = useState(false);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
   const [searchBarContent, setSearchBarContent] = useState(defaultValue);
   const [q, setQ] = useState(null);
   const [t, setT] = useState("products");
@@ -42,26 +43,37 @@ const SearchBar = ({
   return (
     <>
       {redirect && homePage && <Redirect to={`/search?type=${t}&q=${q}`} />}
-      <Search
-        value={searchBarContent}
-        addonBefore={selectBefore}
-        placeholder="I'm looking for..."
-        onChange={(e) => {
-          setSearchBarContent(e.target.value);
-        }}
-        onSearch={(value) => {
-          if (setLoading) setLoading(true);
+      <Tooltip
+        title="Please include a search term."
+        placement="bottom"
+        visible={tooltipVisible}
+      >
+        <Search
+          value={searchBarContent}
+          addonBefore={selectBefore}
+          placeholder="I'm looking for..."
+          onChange={(e) => {
+            setTooltipVisible(false);
+            setSearchBarContent(e.target.value);
+          }}
+          onSearch={(value) => {
+            if (value.length === 0) {
+              setTooltipVisible(true);
+            } else {
+              if (setLoading) setLoading(true);
 
-          if (homePage) {
-            setQ(value);
-            setRedirect(true);
-          } else {
-            setPageNumber(1);
-            setSearchTerm(value);
-          }
-        }}
-        style={{ width: "80%", maxWidth: "650px", borderRadius: "5px" }}
-      />
+              if (homePage) {
+                setQ(value);
+                setRedirect(true);
+              } else {
+                setPageNumber(1);
+                setSearchTerm(value);
+              }
+            }
+          }}
+          style={{ width: "80%", maxWidth: "650px", borderRadius: "5px" }}
+        />
+      </Tooltip>
     </>
   );
 };

--- a/frontend/src/components/Search/SearchBar.jsx
+++ b/frontend/src/components/Search/SearchBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import queryString from "query-string";
 import "./SearchBar.css";
 import { Redirect } from "react-router-dom";
 import { Input, Select, Tooltip } from "antd";
@@ -42,7 +43,9 @@ const SearchBar = ({
 
   return (
     <>
-      {redirect && homePage && <Redirect to={`/search?type=${t}&q=${q}`} />}
+      {redirect && homePage && (
+        <Redirect to={`/search?${queryString.stringify({ type: t, q })}`} />
+      )}
       <Tooltip
         title="Please include a search term."
         placement="bottom"

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -12,6 +12,7 @@ import ResultsList from "./ResultsList.jsx";
 let abortController = new AbortController();
 
 const SearchResults = ({ history, location }) => {
+  // We get redirected here from <SearchBar/> who passes query params
   const queryParams = queryString.parse(location.search);
   const [searchTerm, setSearchTerm] = useState(queryParams.q);
   const [type, setType] = useState(queryParams.type);

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -32,6 +32,15 @@ const SearchResults = ({ history, location }) => {
     setPrice([]);
   }, [searchTerm]);
 
+  // When 'Products' or 'Services' is clicked
+  useEffect(() => {
+    const newType = queryString.parse(location.search).type;
+    if (newType !== type) {
+      setType(newType);
+      setLoading(true);
+    }
+  }, [location.search]);
+
   useEffect(() => {
     const callApi = async () => {
       abortController.abort(); // cancel previous request
@@ -65,9 +74,9 @@ const SearchResults = ({ history, location }) => {
           ? `&warehoused=[${places.map((p) => `"${p}"`)}]`
           : ""
       }`;
+
       const apiUrl = `${baseUrl}/api/${type ? type : ""}?${params}`;
       const pageUrl = `/search?type=${type ? type : ""}&${params}`;
-
       history.push(pageUrl);
 
       try {

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -67,8 +67,24 @@ const SearchResults = ({ history, location }) => {
           : ""
       }`;
 
-      const apiUrl = `${baseUrl}/api/${type ? type : ""}?${params}`;
-      const pageUrl = `/search?type=${type ? type : ""}&${params}`;
+      const testParams = queryString.stringify({
+        page: pageNumber,
+        pageSize,
+        q: searchTerm,
+        tags: tags.map((t) => t.tag),
+        price,
+        companyHQ:
+          places.length > 0 && stages.includes("companyHQ") ? places : [],
+        designed:
+          places.length > 0 && stages.includes("designed") ? places : [],
+        manufactured:
+          places.length > 0 && stages.includes("manufactured") ? places : [],
+        warehoused:
+          places.length > 0 && stages.includes("warehoused") ? places : [],
+      });
+
+      const apiUrl = `${baseUrl}/api/${type ? type : ""}?${testParams}`;
+      const pageUrl = `/search?type=${type ? type : ""}&${testParams}`;
       history.push(pageUrl);
 
       try {

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -26,6 +26,7 @@ const SearchResults = ({ history, location }) => {
   const [pageSize, setPageSize] = useState(10);
   const [loading, setLoading] = useState(true);
 
+  console.log({ items });
   // Clear filters on a new search
   useEffect(() => {
     setTags([]);

--- a/frontend/src/components/Services/Services.jsx
+++ b/frontend/src/components/Services/Services.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Services = () => {
+  return <div>Services yeah</div>;
+};
+
+export default Services;

--- a/frontend/src/styles/styles.js
+++ b/frontend/src/styles/styles.js
@@ -344,13 +344,14 @@ export const SearchFilterBar = styled.div`
 export const ProductsPopover = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 400px;
   height: 400px;
   flex-wrap: wrap;
   overflow: scroll;
 `;
 
-export const CategoryLabel = styled.div`
+export const CategoryLabel = styled.a`
   margin: 10px;
 `;
 

--- a/frontend/src/styles/styles.js
+++ b/frontend/src/styles/styles.js
@@ -22,6 +22,11 @@ export const GlobalStyle = createGlobalStyle`
     color: #5c6475;
   }
 
+  h1 {
+    color: inherit;
+    font-weight: bold;
+  }
+
   a {
     text-decoration: none;
     color: inherit;
@@ -333,5 +338,24 @@ export const SearchFilterBar = styled.div`
   display: flex;
   justify-content: space-evenly;
   width: 100%;
+  align-items: center;
+`;
+
+export const ProductsPopover = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 400px;
+  flex-wrap: wrap;
+  overflow: scroll;
+`;
+
+export const CategoryLabel = styled.div`
+  margin: 10px;
+`;
+
+export const CategorySearchHeader = styled.div`
+  display: flex;
+  flex-direction: row;
   align-items: center;
 `;

--- a/frontend/src/styles/styles.js
+++ b/frontend/src/styles/styles.js
@@ -358,4 +358,37 @@ export const CategorySearchHeader = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: center;
+  width: 100%;
+
+  @media ${devices.tablet} {
+    justify-content: space-between;
+    margin-bottom: 30px;
+  }
+`;
+
+export const BrowseAllTitle = styled.h1`
+  margin-bottom: 0px;
+  margin-right: 50px;
+  text-align: center;
+
+  @media ${devices.tablet} {
+    margin-left: 20px;
+    margin-right: 20px;
+    font-size: 1.6em;
+  }
+  @media ${devices.mobile} {
+    margin-left: 15px;
+    margin-right: 15px;
+    font-size: 1.4em;
+  }
+`;
+
+export const CategoryDropdown = styled(Button)`
+  @media ${devices.mobile} {
+    height: 24px;
+    padding: 0px 7px;
+    font-size: 14px;
+    border-radius: 2px;
+  }
 `;


### PR DESCRIPTION
Working on #7 , still need to do the same for Services. Here's what I did for Products

- Create a new table in Airtable - `Categories (Products)`, link to those
- Modify `products.js` to hydrate records with category information
- Create a new api endpoint `/categories` (should be `/product-categories`) so you can get the full list of categories
- Create a category formula in `products.js` so you can search by category
- Create a <Products/> page which has a route `/products` when clicked on in the nav bar
  - it calls the api with all the appropriate parameters
  - it has a dropdown menu where you can search by category
  - you can use all the same filters as before
- Some weird routing stuff, like when you click on the NavBar category sublinks, you need to <Redirect> to <Products>
